### PR TITLE
Support docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:alpine
+
+WORKDIR /app
+
+
+RUN apk add --update --no-cache --virtual build_images g++ gcc libxslt-dev git && \
+    git clone https://github.com/Foair/course-crawler.git /app && \
+    pip install requests BeautifulSoup4 lxml -i http://pypi.douban.com/simple/ --trusted-host pypi.douban.com && \
+    apk del build_images && \
+    rm -rf /app/README.md /app/LICENSE
+
+COPY ./docker-entrypoint.sh /app
+
+RUN chmod 777 ./docker-entrypoint.sh
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+python mooc.py "$@" -d "/video"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/35299017/44958255-3ea2e300-af10-11e8-91a8-683530d13a4c.png)

`docker run --rm -it -v $(pwd):/video zsnmwy/course-crawler 课堂链接 [option]`

 请不要添加`-d `，这个option了。其他的都无所谓。

在这个镜像里面，直接用`-d`下到容器的`/video`。

`python mooc.py "$@" -d "/video"`

---

`-v $(pwd):/video` 直接挂载当前目录到容器的`/video`，就能够直接下到当前目录。

`--rm` 运行结束后删除当前容器。
